### PR TITLE
added the published version of the Sick Sicker model

### DIFF
--- a/inst/Sick_Sicker_model_published_version/Krijkamp_et_al_2018_appendix_C.R
+++ b/inst/Sick_Sicker_model_published_version/Krijkamp_et_al_2018_appendix_C.R
@@ -131,3 +131,4 @@ table_markov <- data.frame(
 rownames(table_markov) = v.Trt  # name the rows
 colnames(table_markov) = c("Costs", "QALYs","Incremental Costs", "QALYs Gained", "ICER") # name the columns
 table_markov                    # print the table
+


### PR DESCRIPTION
- added the published version of the Sick Sicker model from the published [paper](https://journals.sagepub.com/doi/full/10.1177/0272989X18754513) GitHub [repository](https://github.com/DARTH-git/Microsimulation-tutorial/tree/master).
- resolves #19.